### PR TITLE
Fix CS307-Server Issue#12 "Registration error not returning error object"

### DIFF
--- a/app/src/main/java/com/example/android/virtualpantry/Network/Request.java
+++ b/app/src/main/java/com/example/android/virtualpantry/Network/Request.java
@@ -176,7 +176,13 @@ public class Request {
     private void receive(boolean logError){
         BufferedReader reader = null;
         try {
-            InputStream inputStream = connection.getInputStream();
+        	InputStream inputStream;
+        	//Fetch error stream if you don't get a successful response
+        	if (connection.getResponseCode() >= 400 || connection.getResponseCode() < 200) {
+        		inputStream = connection.getErrorStream();
+        	} else {
+        		inputStream = connection.getInputStream();
+        	}
             reader = new BufferedReader(new InputStreamReader(inputStream));
             String line;
             StringBuffer bufferedResponse = new StringBuffer();
@@ -186,7 +192,7 @@ public class Request {
             }
             this.response = bufferedResponse.toString();
         } catch(IOException e){
-            if(logError) {Log.e(LOG_TAG, "failed to read in receive()", e);}
+            if(logError) { Log.e(LOG_TAG, "failed to read in receive()", e);}
             connectionError = true;
             response = null;
         }


### PR DESCRIPTION
Fixed null reference error when fetching connection input stream.  Response codes outside of the 200-399 range generate error streams instead of input streams.
